### PR TITLE
Custom allocator

### DIFF
--- a/src/imtjson/ivalue.h
+++ b/src/imtjson/ivalue.h
@@ -109,6 +109,10 @@ namespace json {
 		virtual const IValue *unproxy() const = 0;
 
 		virtual bool equal(const IValue *other) const = 0;
+
+		void *operator new(std::size_t);
+		void operator delete(void *, std::size_t);
+
 	};
 
 	class IEnumFn {
@@ -126,6 +130,21 @@ namespace json {
 		}
 	protected:
 		mutable Fn fn;
+	};
+
+	///Declaration of a structure which configures allocator for JSON values.
+	struct Allocator {
+		///Pointer to allocator.
+		/** @param size size to allocate
+		*/
+		void *(*alloc)(std::size_t size);
+		///Pointer to deallocator
+		/** @param pointer to memory to deallocate 
+		 *  @param size count of bytes to deallocate
+		 */
+		void (*dealloc)(void *ptr, std::size_t size);
+
+
 	};
 
 }

--- a/src/imtjson/ivalue.h
+++ b/src/imtjson/ivalue.h
@@ -142,7 +142,7 @@ namespace json {
 		/** @param pointer to memory to deallocate 
 		 *  @param size count of bytes to deallocate
 		 */
-		void (*dealloc)(void *ptr, std::size_t size);
+		void (*dealloc)(void *ptr);
 
 
 	};

--- a/src/imtjson/object.cpp
+++ b/src/imtjson/object.cpp
@@ -51,13 +51,13 @@ namespace json {
 
 	void *ObjectProxy::operator new(std::size_t sz, const StringView<char> &str ) {
 		std::size_t needsz = sz - sizeof(ObjectProxy::key) + str.length+1;
-		return ::operator new(needsz);
+		return Value::allocator->alloc(needsz);
 	}
 	void ObjectProxy::operator delete(void *ptr, const StringView<char> &) {
-		::operator delete (ptr);
+		Value::allocator->dealloc(ptr);
 	}
-	void ObjectProxy::operator delete(void *ptr, std::size_t) {
-		::operator delete (ptr);
+	void ObjectProxy::operator delete(void *ptr, std::size_t sz) {
+		Value::allocator->dealloc(ptr);
 	}
 
 

--- a/src/imtjson/path.cpp
+++ b/src/imtjson/path.cpp
@@ -61,7 +61,7 @@ PPath Path::copy() const {
 		if (p->isKey()) reqSize+=p->keyName.length+1;
 	}
 
-	void *buff = ::operator new(reqSize+sizeof(std::uintptr_t));
+	void *buff = Value::allocator->alloc(reqSize+sizeof(std::uintptr_t));
 
 	std::uintptr_t *cookie = reinterpret_cast<std::uintptr_t *>(
 			reinterpret_cast<char *>(buff)+reqSize);
@@ -118,10 +118,9 @@ void Path::operator delete(void *ptr) {
 	//because object is POD type, it has no destructor
 	//destructor is called when need to delete object
 	//because object is always allocated by copy()
-	//we can nout perform cleanup of whole path
+	//we cannot perform cleanup of whole path
 
-
-	::operator delete (ptr);
+	Value::allocator->dealloc(ptr);
 
 }
 void *Path::operator new(size_t , void *p) {

--- a/src/imtjson/stringValue.cpp
+++ b/src/imtjson/stringValue.cpp
@@ -44,24 +44,24 @@ std::uintptr_t json::AbstractStringValue::getUInt() const {
 
 void* json::StringValue::operator new(std::size_t sz, const StringView<char>& str) {
 	std::size_t needsz = sz - sizeof(StringValue::charbuff) + std::max(str.length+1,magic.length);
-	return putMagic(::operator new(needsz));
+	return putMagic(Value::allocator->alloc(needsz));
 }
 
-void json::StringValue::operator delete(void* ptr,const StringView<char>& str) {
-	::operator delete(ptr);
+void json::StringValue::operator delete(void* ptr,const StringView<char>& ) {
+	Value::allocator->dealloc(ptr);
 }
 
 void* json::StringValue::operator new(std::size_t sz, const std::size_t &strsz) {
 	std::size_t needsz = sz - sizeof(StringValue::charbuff) + std::max(strsz+1, magic.length);
-	return putMagic(::operator new(needsz));
+	return putMagic(Value::allocator->alloc(needsz));
 }
 
-void json::StringValue::operator delete(void* ptr, const std::size_t &sz) {
-	::operator delete(ptr);
+void json::StringValue::operator delete(void* ptr, const std::size_t &) {
+	Value::allocator->dealloc(ptr);
 }
 
-void json::StringValue::operator delete(void* ptr, std::size_t sz) {
-	::operator delete(ptr);
+void json::StringValue::operator delete(void* ptr, std::size_t ) {
+	Value::allocator->dealloc(ptr);
 }
 
 double json::AbstractStringValue::getNumber() const {

--- a/src/imtjson/value.cpp
+++ b/src/imtjson/value.cpp
@@ -342,9 +342,9 @@ namespace json {
 		unsigned char table[256];
 		Base64Table() {
 			for (std::size_t i = 0; i <256; i++) table[i] = 0xFF;
-			for (std::size_t i = 'A'; i <='Z'; i++) table[i] = i - 'A';
-			for (std::size_t i = 'a'; i <='z'; i++) table[i] = i - 'a' + 26;
-			for (std::size_t i = '0'; i <='9'; i++) table[i] = i - '0' + 52;
+			for (std::size_t i = 'A'; i <='Z'; i++) table[i] = (unsigned char)(i - 'A');
+			for (std::size_t i = 'a'; i <= 'z'; i++) table[i] = (unsigned char)(i - 'a' + 26);
+			for (std::size_t i = '0'; i <='9'; i++) table[i] = (unsigned char)(i - '0' + 52);
 			table['+'] = 63;
 			table['/'] = 64;
 		}
@@ -491,6 +491,20 @@ namespace json {
 		v = s.getHandle();
 	}
 
+	static Allocator defaultAllocator = {
+		&::operator new,
+		&::operator delete
+	};
+
+
+	const Allocator * Value::allocator = &defaultAllocator;
+
+	void *IValue::operator new(std::size_t sz) {
+		return Value::allocator->alloc(sz);
+	}
+	void IValue::operator delete(void *ptr, std::size_t sz) {
+		return Value::allocator->dealloc(ptr, sz);
+	}
 
 }
 

--- a/src/imtjson/value.cpp
+++ b/src/imtjson/value.cpp
@@ -491,6 +491,8 @@ namespace json {
 		v = s.getHandle();
 	}
 
+
+
 	static Allocator defaultAllocator = {
 		&::operator new,
 		&::operator delete
@@ -502,8 +504,8 @@ namespace json {
 	void *IValue::operator new(std::size_t sz) {
 		return Value::allocator->alloc(sz);
 	}
-	void IValue::operator delete(void *ptr, std::size_t sz) {
-		return Value::allocator->dealloc(ptr, sz);
+	void IValue::operator delete(void *ptr, std::size_t) {
+		return Value::allocator->dealloc(ptr);
 	}
 
 }

--- a/src/imtjson/value.h
+++ b/src/imtjson/value.h
@@ -744,6 +744,18 @@ namespace json {
 			return v->unproxy() < other.v->unproxy();
 		}
 
+public:
+
+		///Pointer to custom allocator
+		/** You can change allocator to achieve better results with allocation 
+		   of values of the JSON. By default, standard new and delete is used.
+		   This variable is global. By changing it, your allocator must
+		   expect, that some objects are already allocated and will be deallocated
+		   through your deallocator.		   
+		*/
+		static const Allocator *allocator;
+
+
 protected:
 
 		PValue v;

--- a/src/tests/main.cpp
+++ b/src/tests/main.cpp
@@ -86,7 +86,7 @@ void subobject(Object &&obj) {
 }
 
 
-int main(int , char **) {
+int testMain() {
 	TestSimple tst;
 
 	//Normalize test across platforms
@@ -856,32 +856,16 @@ tst.test("Object.enumItems", "age:19,data:[90,60,90],frobla:12.3,kabrt:289,name:
 	tst.test("compress.utf-8","ok") >> [](std::ostream &out) {
 		if (compressTest("src/tests/test2.json")) out << "ok"; else out << "not same";
 	};
-#if 0 //removed because imtjson is leaving allocated some objects which are deleted at-exit
-	{
-		//memory leaks
-		//out of test class, because it can affect the test
-		bool win32detected = false;
-#ifdef _WIN32
-		if (_CrtDumpMemoryLeaks()) {
-			win32detected = true;
-		}
-#endif
-
-		Value x(10);
-#ifdef _WIN32
-		int lcounter = leakCounter - 1;
-		if (lcounter == 1) lcounter--; //< windows can allocates extra mem during test
-#else
-		int lcounter = leakCounter - 1;
-#endif
-		tst.test("MemoryLeaks", "0") >> [=](std::ostream &out) {
-			if (win32detected)
-				out << "Detected memory leaks!";
-			out << lcounter;
-		};
 
 
-	}
-#endif
 	return tst.didFail()?1:0;
+}
+
+int main(int, char **) {
+	int r = testMain();
+#ifdef _WIN32
+	_CrtDumpMemoryLeaks();
+#endif
+	return r;
+
 }


### PR DESCRIPTION
You can define a custom allocator which is used to allocate space for values and other internals. 

Custom allocator is global property. It defaults to standard new and standard delete.  Through the object Allocator you can declare a custom global functions for allocation and deallocation and redirect the pointer Value::allocator to point to that object.