### PR TITLE
Added #includes for passing build with g++ (GCC) 6.3.1

### DIFF
--- a/src/imtjson/parser.h
+++ b/src/imtjson/parser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sstream>
+#include <cmath>
 #include "object.h"
 #include "array.h"
 

--- a/src/imtjson/serializer.h
+++ b/src/imtjson/serializer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <cmath>
 #include <vector>
 #include "value.h"
 

--- a/src/imtjson/stackProtection.h
+++ b/src/imtjson/stackProtection.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
 
 namespace json {
 


### PR DESCRIPTION
On Fedora 25, build doesn't work out-of-the-box.

- type `std::uintptr_t` is unknown in `src/imtjson/stackProtection.h`
- couple of unknown math functions in `src/imtjson/parser.h` and `src/imtjson/serializer.h`

Compiler info: `g++ (GCC) 6.3.1 20161221 (Red Hat 6.3.1-1)`

🇨🇿 